### PR TITLE
同じネットワークに複数のNICを接続できるようにする

### DIFF
--- a/app/Http/Controllers/MachinesController.php
+++ b/app/Http/Controllers/MachinesController.php
@@ -119,9 +119,11 @@ class MachinesController extends Controller
 
     public function nic(Problem $problem, Machine $machine)
     {
+        $networks = $problem->networks()->get();
         return view('pages.problems.machines.attach_nic', [
             'problem' => $problem,
             'machine' => $machine,
+            'networks' => $networks,
         ]);
     }
 

--- a/database/migrations/2024_02_23_094514_drop_primary_key_from_attached_nics.php
+++ b/database/migrations/2024_02_23_094514_drop_primary_key_from_attached_nics.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropPrimaryKeyFromAttachedNics extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('attached_nics', function (Blueprint $table) {
+            $table->dropForeign('attached_nics_machine_id_foreign');
+            $table->dropForeign('attached_nics_network_id_foreign');
+            $table->dropPrimary(['machine_id', 'network_id']);
+            $table->foreign('machine_id')->references('id')->on('machines');
+            $table->foreign('network_id')->references('id')->on('networks');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('attached_nics', function (Blueprint $table) {
+            $table->primary(['machine_id', 'network_id']);
+        });
+    }
+}

--- a/resources/views/pages/problems/machines/attach_nic.blade.php
+++ b/resources/views/pages/problems/machines/attach_nic.blade.php
@@ -11,16 +11,13 @@
             VMにNICを追加する
           </div>
           <div class="card-body">
-            <?php
-              $networks = $problem->networks()->whereNotIn('id', array_column($machine->attachedNics->toArray(), 'id'))->get();
-            ?>
-            @if(count($networks) == 0) 
-              接続できるネットワークがありません。
-              <div>
-                <a class="btn btn-secondary" href="{{ route('problems.show', [
+            @if(count($networks) == 0)
+            接続できるネットワークがありません。
+            <div>
+              <a class="btn btn-secondary" href="{{ route('problems.show', [
                 'problem' => $problem,
               ]) }}">戻る</a>
-              </div>
+            </div>
             @else
             <form action="{{ route('problems.machines.nics.attach', [
               'problem' => $problem,
@@ -49,8 +46,7 @@
               </div>
               <div class="form-group">
                 <label for="nameserver">nameserver</label>
-                <input type="text" class="form-control" id="nameserver" name="nameserver"
-                  placeholder="xxx.xxx.xxx.xxx">
+                <input type="text" class="form-control" id="nameserver" name="nameserver" placeholder="xxx.xxx.xxx.xxx">
               </div>
               <div class="form-group">
                 <label for="order">順番</label>


### PR DESCRIPTION
machinesとnetworksの中間テーブルであるattached_nicsではmachine_idとnetwork_idの複合主キーを設定しているため、複数のNICを同じネットワークに設定することができない。

複合主キーを削除し中間テーブルに重複して設定できるようにする。